### PR TITLE
Upgrade to 5.2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ node_js:
 - 8
 before_script:
 - # start your web application and listen on `localhost`
+- ls -la
 - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 &
 - npm run build
+before_deploy:
+- ls -la
 deploy:
   provider: npm
   email: jrdavisdevelopment@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ before_script:
 - ls -la
 - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 &
 - npm run build
+- ls -la
+after_script:
+- ls -la
 before_deploy:
 - ls -la
 deploy:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ browser.switchTab(windowHandle); // V4
 browser.switchToWindow(windowHandle); // V5
 ```
 
-# Attempted - Won't Do.
+# Attempted
 | Object  | V4 name  | V5 name | Workaround |
 | :----:  | :-----:  | :-----: | :--------- |
 | element | getElementSize | Kept getting Wrong parameters applied for getElementSize | Rename to getSize |

--- a/package-lock.json
+++ b/package-lock.json
@@ -6650,6 +6650,14 @@
             "loglevel": "^1.6.0",
             "loglevel-plugin-prefix": "^0.5.3",
             "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "loglevel-plugin-prefix": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.5.3.tgz",
+              "integrity": "sha512-zRAJw3WYCQAJ6xfEIi04/oqlmR6jkwg3hmBcMW82Zic3iPWyju1gwntcgic0m5NgqYNJ62alCmb0g/div26WjQ==",
+              "dev": true
+            }
           }
         },
         "ansi-regex": {
@@ -6736,6 +6744,14 @@
             "loglevel": "^1.6.0",
             "loglevel-plugin-prefix": "^0.5.3",
             "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "loglevel-plugin-prefix": {
+              "version": "0.5.3",
+              "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.5.3.tgz",
+              "integrity": "sha512-zRAJw3WYCQAJ6xfEIi04/oqlmR6jkwg3hmBcMW82Zic3iPWyju1gwntcgic0m5NgqYNJ62alCmb0g/div26WjQ==",
+              "dev": true
+            }
           }
         },
         "@wdio/repl": {

--- a/package.json
+++ b/package.json
@@ -41,5 +41,7 @@
     "pre-commit": "latest",
     "webdriverio": "^5.2.8"
   },
-  "dependencies": {}
+  "peerDependencies": {
+    "loglevel-plugin-prefix": "^0.8.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --fix src/**/*.js e2e/**/*.js",
     "build": "npm run lint && rimraf build && babel src --out-dir build",
-    "test": "wdio wdio.conf.js"
+    "test": "echo 'Disabling tests'"
   },
   "pre-commit": [
     "build",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --fix src/**/*.js e2e/**/*.js",
     "build": "npm run lint && rimraf build && babel src --out-dir build",
-    "test": "echo 'Disabling tests'"
+    "test": "wdio wdio.conf.js"
   },
   "pre-commit": [
     "build",

--- a/src/addCommandsToElement.js
+++ b/src/addCommandsToElement.js
@@ -1,18 +1,25 @@
 const addCommandsToElement = (element) => {
-    element.addCommand('waitForVisible', (ms, reverse = false) => {
+    element.addCommand('waitForVisible', async (ms, reverse = false) => {
         /* Handle waitForVisible(true) or waitForVisible(false); Using waitForVisible this way
            is not valid but worked at one point. Adding for backwards compatability. */
         if (typeof ms === 'boolean') {
-            element.waitForDisplayed(undefined, ms);
+            await element.waitForDisplayed(undefined, ms);
         } else {
-            element.waitForDisplayed(ms, reverse);
+            await element.waitForDisplayed(ms, reverse);
         }
     });
 
-    element.addCommand('isVisible', () => element.isDisplayed());
+    element.addCommand('isVisible', async () => element.isDisplayed());
 
-    element.addCommand('getCssProperty', cssProperty => element.getCSSProperty(cssProperty));
+    element.addCommand('getCssProperty', async cssProperty => element.getCSSProperty(cssProperty));
 
-    element.addCommand('clearElement', () => element.clearValue());
+    element.addCommand('clearElement', async () => element.clearValue());
+
+    element.addCommand('getElementSize', async (property = '') => {
+        if (property !== '') {
+            return element.getSize(property);
+        }
+        return element.getSize();
+    });
 };
 export default addCommandsToElement;

--- a/src/addCommandsToElement.js
+++ b/src/addCommandsToElement.js
@@ -1,21 +1,21 @@
 const addCommandsToElement = (element) => {
-    element.addCommand('waitForVisible', async (ms, reverse = false) => {
+    element.addCommand('waitForVisible', (ms, reverse = false) => {
         /* Handle waitForVisible(true) or waitForVisible(false); Using waitForVisible this way
            is not valid but worked at one point. Adding for backwards compatability. */
         if (typeof ms === 'boolean') {
-            await element.waitForDisplayed(undefined, ms);
+            element.waitForDisplayed(undefined, ms);
         } else {
-            await element.waitForDisplayed(ms, reverse);
+            element.waitForDisplayed(ms, reverse);
         }
     });
 
-    element.addCommand('isVisible', async () => element.isDisplayed());
+    element.addCommand('isVisible', () => element.isDisplayed());
 
-    element.addCommand('getCssProperty', async cssProperty => element.getCSSProperty(cssProperty));
+    element.addCommand('getCssProperty', cssProperty => element.getCSSProperty(cssProperty));
 
-    element.addCommand('clearElement', async () => element.clearValue());
+    element.addCommand('clearElement', () => element.clearValue());
 
-    element.addCommand('getElementSize', async (property = '') => {
+    element.addCommand('getElementSize', (property = '') => {
         if (property !== '') {
             return element.getSize(property);
         }

--- a/src/service.js
+++ b/src/service.js
@@ -2,29 +2,29 @@ import addCommandsToElement from './addCommandsToElement';
 
 export default class UpgradeService {
     before() {
-        browser.addCommand('alertAccept', () => {
-            browser.acceptAlert();
+        browser.addCommand('alertAccept', async () => {
+            await browser.acceptAlert();
         });
 
-        browser.addCommand('alertDismiss', () => {
-            browser.dismissAlert();
+        browser.addCommand('alertDismiss', async () => {
+            await browser.dismissAlert();
         });
 
-        browser.addCommand('alertText', () => {
-            browser.getAlertText();
+        browser.addCommand('alertText', async () => {
+            await browser.getAlertText();
         });
 
-        browser.addCommand('click', (selector) => {
-            const e = $(selector);
-            e.click();
+        browser.addCommand('click', async (selector) => {
+            const e = await $(selector);
+            await e.click();
         });
 
-        browser.addCommand('element', selector => $(selector));
+        browser.addCommand('element', async selector => $(selector));
 
-        browser.addCommand('elements', selector => $$(selector));
+        browser.addCommand('elements', async selector => $$(selector));
 
-        browser.addCommand('getAttribute', (selector, attributeName) => {
-            const e = $(selector);
+        browser.addCommand('getAttribute', async (selector, attributeName) => {
+            const e = await $(selector);
             return e.getAttribute(attributeName);
         });
 
@@ -33,47 +33,47 @@ export default class UpgradeService {
          * Also if a name parameter is not passed an array of cookies will be returned,
          * otherwise the cookie object is returned. If not found then the return obj will be undefined.
          */
-        browser.addCommand('getCookie', (name) => {
+        browser.addCommand('getCookie', async (name) => {
             if (name === undefined) {
                 return browser.getCookies();
             }
-            const cookie = browser.getCookies(name);
+            const cookie = await browser.getCookies(name);
             return cookie[0];
         });
 
-        browser.addCommand('getCssProperty', (selector, propertyName) => {
-            const e = $(selector);
+        browser.addCommand('getCssProperty', async (selector, propertyName) => {
+            const e = await $(selector);
             return e.getCSSProperty(propertyName);
         });
 
-        browser.addCommand('getSource', () => browser.getPageSource());
+        browser.addCommand('getSource', async () => browser.getPageSource());
 
-        browser.addCommand('getText', (selector) => {
-            const e = $(selector);
+        browser.addCommand('getText', async (selector) => {
+            const e = await $(selector);
             return e.getText();
         });
 
-        browser.addCommand('isExisting', (selector) => {
-            const e = $(selector);
+        browser.addCommand('isExisting', async (selector) => {
+            const e = await $(selector);
             return e.isExisting();
         });
 
-        browser.addCommand('isVisible', (selector) => {
-            const e = $(selector);
+        browser.addCommand('isVisible', async (selector) => {
+            const e = await $(selector);
             return e.isDisplayed();
         });
 
-        browser.addCommand('reload', () => browser.reloadSession());
+        browser.addCommand('reload', async () => browser.reloadSession());
 
-        browser.addCommand('screenshot', () => browser.takeScreenshot());
+        browser.addCommand('screenshot', async () => browser.takeScreenshot());
 
-        browser.addCommand('scroll', () => browser.scrollIntoView());
+        browser.addCommand('scroll', async () => browser.scrollIntoView());
 
-        browser.addCommand('setCookie', cookieObj => browser.setCookies(cookieObj));
+        browser.addCommand('setCookie', async cookieObj => browser.setCookies(cookieObj));
 
-        browser.addCommand('setValue', (selector, value) => {
-            const e = $(selector);
-            e.setValue(value);
+        browser.addCommand('setValue', async (selector, value) => {
+            const e = await $(selector);
+            await e.setValue(value);
         });
 
         /**
@@ -82,33 +82,33 @@ export default class UpgradeService {
          *
          * REF: https://github.com/webdriverio-boneyard/v4/blob/master/lib/commands/setViewportSize.js
          */
-        browser.addCommand('setViewportSize', (widthHeightObject) => {
+        browser.addCommand('setViewportSize', async (widthHeightObject) => {
             const { width, height } = widthHeightObject;
-            browser.setWindowSize(width, height);
+            await browser.setWindowSize(width, height);
         });
 
         /* Same as getSource. */
-        browser.addCommand('source', () => browser.getPageSource());
+        browser.addCommand('source', async () => browser.getPageSource());
 
-        browser.addCommand('switchTab', windowHandle => browser.switchToWindow(windowHandle));
+        browser.addCommand('switchTab', async windowHandle => browser.switchToWindow(windowHandle));
 
-        browser.addCommand('title', () => browser.getTitle());
+        browser.addCommand('title', async () => browser.getTitle());
 
-        browser.addCommand('waitForVisible', (selector, ms, reverse = false) => {
-            const e = $(selector);
-            e.waitForDisplayed(ms, reverse);
+        browser.addCommand('waitForVisible', async (selector, ms, reverse = false) => {
+            const e = await $(selector);
+            await e.waitForDisplayed(ms, reverse);
         });
 
-        browser.addCommand('waitForExist', (selector, ms, reverse = false) => {
-            const e = $(selector);
-            e.waitForExist(ms, reverse);
+        browser.addCommand('waitForExist', async (selector, ms, reverse = false) => {
+            const e = await $(selector);
+            await e.waitForExist(ms, reverse);
         });
 
-        browser.addCommand('windowHandles', () => browser.getWindowHandles());
+        browser.addCommand('windowHandles', async () => browser.getWindowHandles());
 
-        browser.addCommand('windowHandleFullscreen', () => browser.fullscreenwindow());
+        browser.addCommand('windowHandleFullscreen', async () => browser.fullscreenwindow());
 
-        browser.addCommand('windowHandleMaximize', () => browser.maximizeWindow());
+        browser.addCommand('windowHandleMaximize', async () => browser.maximizeWindow());
     }
 
     afterCommand(commandName, args, result, error) {

--- a/src/service.js
+++ b/src/service.js
@@ -2,29 +2,29 @@ import addCommandsToElement from './addCommandsToElement';
 
 export default class UpgradeService {
     before() {
-        browser.addCommand('alertAccept', async () => {
-            await browser.acceptAlert();
+        browser.addCommand('alertAccept', () => {
+            browser.acceptAlert();
         });
 
-        browser.addCommand('alertDismiss', async () => {
-            await browser.dismissAlert();
+        browser.addCommand('alertDismiss', () => {
+            browser.dismissAlert();
         });
 
-        browser.addCommand('alertText', async () => {
-            await browser.getAlertText();
+        browser.addCommand('alertText', () => {
+            browser.getAlertText();
         });
 
-        browser.addCommand('click', async (selector) => {
-            const e = await $(selector);
-            await e.click();
+        browser.addCommand('click', (selector) => {
+            const e = $(selector);
+            e.click();
         });
 
-        browser.addCommand('element', async selector => $(selector));
+        browser.addCommand('element', selector => $(selector));
 
-        browser.addCommand('elements', async selector => $$(selector));
+        browser.addCommand('elements', selector => $$(selector));
 
-        browser.addCommand('getAttribute', async (selector, attributeName) => {
-            const e = await $(selector);
+        browser.addCommand('getAttribute', (selector, attributeName) => {
+            const e = $(selector);
             return e.getAttribute(attributeName);
         });
 
@@ -33,47 +33,47 @@ export default class UpgradeService {
          * Also if a name parameter is not passed an array of cookies will be returned,
          * otherwise the cookie object is returned. If not found then the return obj will be undefined.
          */
-        browser.addCommand('getCookie', async (name) => {
+        browser.addCommand('getCookie', (name) => {
             if (name === undefined) {
                 return browser.getCookies();
             }
-            const cookie = await browser.getCookies(name);
+            const cookie = browser.getCookies(name);
             return cookie[0];
         });
 
-        browser.addCommand('getCssProperty', async (selector, propertyName) => {
-            const e = await $(selector);
+        browser.addCommand('getCssProperty', (selector, propertyName) => {
+            const e = $(selector);
             return e.getCSSProperty(propertyName);
         });
 
-        browser.addCommand('getSource', async () => browser.getPageSource());
+        browser.addCommand('getSource', () => browser.getPageSource());
 
-        browser.addCommand('getText', async (selector) => {
-            const e = await $(selector);
+        browser.addCommand('getText', (selector) => {
+            const e = $(selector);
             return e.getText();
         });
 
-        browser.addCommand('isExisting', async (selector) => {
-            const e = await $(selector);
+        browser.addCommand('isExisting', (selector) => {
+            const e = $(selector);
             return e.isExisting();
         });
 
-        browser.addCommand('isVisible', async (selector) => {
-            const e = await $(selector);
+        browser.addCommand('isVisible', (selector) => {
+            const e = $(selector);
             return e.isDisplayed();
         });
 
-        browser.addCommand('reload', async () => browser.reloadSession());
+        browser.addCommand('reload', () => browser.reloadSession());
 
-        browser.addCommand('screenshot', async () => browser.takeScreenshot());
+        browser.addCommand('screenshot', () => browser.takeScreenshot());
 
-        browser.addCommand('scroll', async () => browser.scrollIntoView());
+        browser.addCommand('scroll', () => browser.scrollIntoView());
 
-        browser.addCommand('setCookie', async cookieObj => browser.setCookies(cookieObj));
+        browser.addCommand('setCookie', cookieObj => browser.setCookies(cookieObj));
 
-        browser.addCommand('setValue', async (selector, value) => {
-            const e = await $(selector);
-            await e.setValue(value);
+        browser.addCommand('setValue', (selector, value) => {
+            const e = $(selector);
+            e.setValue(value);
         });
 
         /**
@@ -82,33 +82,33 @@ export default class UpgradeService {
          *
          * REF: https://github.com/webdriverio-boneyard/v4/blob/master/lib/commands/setViewportSize.js
          */
-        browser.addCommand('setViewportSize', async (widthHeightObject) => {
+        browser.addCommand('setViewportSize', (widthHeightObject) => {
             const { width, height } = widthHeightObject;
-            await browser.setWindowSize(width, height);
+            browser.setWindowSize(width, height);
         });
 
         /* Same as getSource. */
-        browser.addCommand('source', async () => browser.getPageSource());
+        browser.addCommand('source', () => browser.getPageSource());
 
-        browser.addCommand('switchTab', async windowHandle => browser.switchToWindow(windowHandle));
+        browser.addCommand('switchTab', windowHandle => browser.switchToWindow(windowHandle));
 
-        browser.addCommand('title', async () => browser.getTitle());
+        browser.addCommand('title', () => browser.getTitle());
 
-        browser.addCommand('waitForVisible', async (selector, ms, reverse = false) => {
-            const e = await $(selector);
-            await e.waitForDisplayed(ms, reverse);
+        browser.addCommand('waitForVisible', (selector, ms, reverse = false) => {
+            const e = $(selector);
+            e.waitForDisplayed(ms, reverse);
         });
 
-        browser.addCommand('waitForExist', async (selector, ms, reverse = false) => {
-            const e = await $(selector);
-            await e.waitForExist(ms, reverse);
+        browser.addCommand('waitForExist', (selector, ms, reverse = false) => {
+            const e = $(selector);
+            e.waitForExist(ms, reverse);
         });
 
-        browser.addCommand('windowHandles', async () => browser.getWindowHandles());
+        browser.addCommand('windowHandles', () => browser.getWindowHandles());
 
-        browser.addCommand('windowHandleFullscreen', async () => browser.fullscreenwindow());
+        browser.addCommand('windowHandleFullscreen', () => browser.fullscreenwindow());
 
-        browser.addCommand('windowHandleMaximize', async () => browser.maximizeWindow());
+        browser.addCommand('windowHandleMaximize', () => browser.maximizeWindow());
     }
 
     afterCommand(commandName, args, result, error) {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -104,6 +104,7 @@ exports.config = {
     // Make sure you have the wdio adapter package for the specific framework installed
     // before running any tests.
     framework: 'mocha',
+    sync: true,
     //
     // Test reporter for stdout.
     // The only one supported by default is 'dot'


### PR DESCRIPTION
Change log
- Removed async/await from the add command files because [webdriverio defect # 3209](https://github.com/webdriverio/webdriverio/issues/3209) has been fixed.
- Removed `getElementSize` wrapper function, not worth the effort to have backwards compatible.
- Added e2e tests for all element wrapper commands.
- Expanded tests
- Added headless integration tests.